### PR TITLE
fix string and date parsing

### DIFF
--- a/cl-xlsx.asd
+++ b/cl-xlsx.asd
@@ -10,4 +10,4 @@
   :components ((:file "package")
                (:file "cl-xlsx"))
   :description "Read LibreOffice ODS files and LibreOffice and Microsoft XLSX files using Common Lisp"
-  :depends-on (:cxml :zip :babel))
+  :depends-on (:cxml :zip :babel :xpath :fxml :parse-number :local-time))


### PR DESCRIPTION
 * fix parsing of shared strings to handle rich text runs

 * return a local-time:timestamp for date / datetime fields instead of
   just a number

 * these changes use xpath, fxml, parse-number, and local-time
   libraries -- all of which are available in quicklisp.