### PR TITLE
check for Microsoft Macintosh Excel in app-type

### DIFF
--- a/cl-xlsx.lisp
+++ b/cl-xlsx.lisp
@@ -523,7 +523,8 @@ more detailed information on sheets for that."
            (if (member "meta.xml" inner-files :test #'string=)
                "ods-libreoffice"
                "xlsx-libreoffice"))
-          ((starts-with-p (app-name xlsx) "Microsoft Excel")
+          ((or (starts-with-p (app-name xlsx) "Microsoft Excel")
+               (starts-with-p (app-name xlsx) "Microsoft Macintosh Excel"))
            "xlsx-microsoft"))))
 
 (defun sheet-names (xlsx)


### PR DESCRIPTION
 * before we only checked for "Microsoft Excel". Some excel files use
   the application name "Microsoft Macintosh Excel." Check for this
   name in app-type.